### PR TITLE
Fix branch for adwaita theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ _build/warning:
 
 _internal-repo: _build/warning
 	[ -d _build/gtk ] && \
-		(cd _build/gtk; git fetch origin; git reset --hard origin/wip/jimmac/adwaita-3-32) || \
-		git clone --depth=1 -b wip/jimmac/adwaita-3-32 \
+		(cd _build/gtk; git fetch origin; git reset --hard origin/wip/jimmac/adwaita-3-32-noshadow) || \
+		git clone --depth=1 -b wip/jimmac/adwaita-3-32-noshadow \
 			https://gitlab.gnome.org/GNOME/gtk.git _build/gtk
 	[ -d _build/adwaita-icon-theme ] && \
 		(cd _build/adwaita-icon-theme; git fetch origin; git reset --hard origin/master) || \


### PR DESCRIPTION
Base branch https://gitlab.gnome.org/GNOME/gtk/tree/wip/jimmac/adwaita-3-32 is no longer available.
Using https://gitlab.gnome.org/GNOME/gtk/tree/wip/jimmac/adwaita-3-32-noshadow instead.